### PR TITLE
Fix sending previous data on change event

### DIFF
--- a/demo/fear_the_goblin.js
+++ b/demo/fear_the_goblin.js
@@ -72,3 +72,4 @@ console.log(goblinDB.ambush.list());
 console.log('Check ambush that apply a math operation');
 goblinDB.ambush.run('testing-goblin', 5, 2);
 goblinDB.ambush.details('testing-goblin').action(9, 2, 3);
+process.exit();

--- a/lib/database.js
+++ b/lib/database.js
@@ -81,7 +81,7 @@ function get(point) {
  */
 function push(data, point) {
 	if (!point) {
-		point = '';
+        point = '';
 	} else if (typeof(point) === 'string') {
 		point = point + '.';
 	} else {
@@ -142,13 +142,13 @@ function set(data, point, silent) {
 			return logger('DB_SAVE_ARRAY');
 		}
 
-		!silent && goblin.goblinDataEmitter.emit('change', {
-			type: 'set',
-			value: data,
-			oldValue: goblin.db
-		});
-
+		const oldValue = goblin.db;
 		goblin.db = data;
+		!silent && goblin.goblinDataEmitter.emit('change', {
+			type: 'update',
+			value: goblin.db,
+			oldValue: oldValue
+		});
 	}
 }
 
@@ -178,7 +178,7 @@ function update(data, point) {
 				parent = parent[tree[i]];
 			} else {
 				const oldValue = parent[tree[i]];
-				parent[tree[i]] = _.merge({}, goblin.db, data);
+				parent[tree[i]] = Object.assign({}, goblin.db, data);
 				goblin.goblinDataEmitter.emit('change', {
 					type: 'update',
 					value: parent[tree[i]],
@@ -193,7 +193,7 @@ function update(data, point) {
 		}
 
 		const oldValue = goblin.db;
-		goblin.db = _.merge({}, goblin.db, data);
+		goblin.db = Object.assign({}, goblin.db, data);
 		goblin.goblinDataEmitter.emit('change', {
 			type: 'update',
 			value: goblin.db,

--- a/lib/database.js
+++ b/lib/database.js
@@ -81,7 +81,7 @@ function get(point) {
  */
 function push(data, point) {
 	if (!point) {
-        point = '';
+		point = '';
 	} else if (typeof(point) === 'string') {
 		point = point + '.';
 	} else {

--- a/lib/database.js
+++ b/lib/database.js
@@ -145,7 +145,7 @@ function set(data, point, silent) {
 		const oldValue = goblin.db;
 		goblin.db = data;
 		!silent && goblin.goblinDataEmitter.emit('change', {
-			type: 'update',
+			type: 'set',
 			value: goblin.db,
 			oldValue: oldValue
 		});


### PR DESCRIPTION
Fix sending previous data on change event instead of the new one (set method) in database.js