### PR TITLE
Error messages referencing FAQ. Closes #14

### DIFF
--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -11,12 +11,16 @@ goblin.errorEmitter.on('error', function (exception, error) {
 	});
 });
 
-function goblinException(prefix, log) {
+function goblinException(prefix, code, log) {
 	this.prefix = prefix;
 	this.log = log;
 
 	this.toString = function() {
 		return (this.prefix ? this.prefix + ': ' : '') + this.log;
+	};
+	this.faqString = function() {
+		return 'Check the F.A.Q. at https://github.com/GoblinDBRocks/GoblinDB/wiki/Errors#' +
+		code.toLowerCase() + ' for more information. 👺';
 	};
 }
 
@@ -25,18 +29,13 @@ module.exports = function(code, error, type) {
 
 	const prefix = goblin.config.logPrefix;
 	const log = errors[code] || code;
-	const exception = new goblinException(prefix, log);
+	const exception = new goblinException(prefix, code, log);
 
 	// Always emit error event
 	goblin.errorEmitter.emit('error', exception, error || {});
-
 	if (currentMode === mode.strict) {
 		throw exception.toString();
 	} else if (currentMode === mode.development) {
-		if (error) {
-			console[type || 'error'](exception.toString(), error);
-		} else {
-			console[type || 'error'](exception.toString());
-		}
+		console[type || 'error'](exception.toString(), exception.faqString(), error ? error : ''	);
 	}
 };


### PR DESCRIPTION
The logger code for outputting messsages when running in dev mode has been modified. Now it provides a message pointing to the corresponding error in the wiki using its code. For example:

`[GoblinDB]: Ambush execution warning: no CALLBACK provided or CALLBACK is not a function. Check the F.A.Q. at https://github.com/GoblinDBRocks/GoblinDB/wiki/Errors#ambush_no_callback for more information. 👺`